### PR TITLE
Use basic image for release

### DIFF
--- a/construi.yml
+++ b/construi.yml
@@ -6,6 +6,8 @@ targets:
     - docker build latest/
 
   release:
+    image: ubuntu:latest
+    privileged: false
     files:
       - $GIT_SSH_KEY:/root/.ssh/id_rsa:0600
     run: bash construi/release/script.sh


### PR DESCRIPTION
No need to use the docker and privileged image for simple git steps
